### PR TITLE
Jan fix

### DIFF
--- a/gate-pbt/simulation/generatefiles.py
+++ b/gate-pbt/simulation/generatefiles.py
@@ -391,7 +391,7 @@ def generate_files(ct_file, plan_file, dose_files, PATH_TO_TEMPLATES, DATA, conf
         # Simulate Nreq/2000 for reasonable stats
         splits = 25
         #nprotons = int( req_prims[field.BeamName]/2000 )
-        nprotons = 2000000
+        nprotons = 2000000 * splits
         jobsplitter.split_by_primaries( mac_filename, primaries=nprotons, splits=splits)
         
        

--- a/gate-pbt/simulation/generatefiles.py
+++ b/gate-pbt/simulation/generatefiles.py
@@ -390,7 +390,8 @@ def generate_files(ct_file, plan_file, dose_files, PATH_TO_TEMPLATES, DATA, conf
         ##### Split field mac file here ####
         # Simulate Nreq/2000 for reasonable stats
         splits = 25
-        nprotons = int( req_prims[field.BeamName]/2000 )      
+        #nprotons = int( req_prims[field.BeamName]/2000 )
+        nprotons = 2000000
         jobsplitter.split_by_primaries( mac_filename, primaries=nprotons, splits=splits)
         
        

--- a/gate-pbt/simulation/run.py
+++ b/gate-pbt/simulation/run.py
@@ -254,7 +254,7 @@ def main():
     crop_to_contour = overrides.get_external_name( struct_file )
     #
     #!!!!!!
-    crop_to_contour="Dose 0.1[%]"   #"D0.001%"  
+    crop_to_contour="Dose0.1%"   #"D0.001%"  
     #
     print("Cropping img to", crop_to_contour)
     ct_cropped = cropimage.crop_to_structure( ct_air_override, struct_file, crop_to_contour) #optional margin

--- a/gate-pbt/simulation/run.py
+++ b/gate-pbt/simulation/run.py
@@ -11,6 +11,7 @@ from os.path import join, basename, isdir, exists
 import shutil
 from pathlib import Path
 import json
+import time
 
 import pydicom
 import easygui
@@ -219,11 +220,16 @@ def main():
     ct_reor = reorientate.force_positive_directionality(ctimg)
     #itk.imwrite(ct_reor,join(sim_dir, "data", "ct_orig_reorientate.mhd"))   
     
-    
-    
+    #t1 = time.perf_counter()
+
     print("Overriding all external structures to air")
     ct_air_override = overrides.set_air_external( ct_reor, struct_file )
     #itk.imwrite(ct_air_override, join(sim_dir,"data","ct_air.mhd"))
+    
+    #t2 = time.perf_counter();
+    #tt = (t2-t1)/60
+    #print("  -> Time to override external air = ", tt) 
+    
     
     
     #
@@ -248,7 +254,7 @@ def main():
     crop_to_contour = overrides.get_external_name( struct_file )
     #
     #!!!!!!
-    crop_to_contour="Dose0.1%"   #"D0.001%"  
+    crop_to_contour="Dose 0.1[%]"   #"D0.001%"  
     #
     print("Cropping img to", crop_to_contour)
     ct_cropped = cropimage.crop_to_structure( ct_air_override, struct_file, crop_to_contour) #optional margin

--- a/gate-pbt/simulation/run.py
+++ b/gate-pbt/simulation/run.py
@@ -23,6 +23,7 @@ import overrides
 import generatefiles
 import config
 import cropimage
+import slurm
 
 
 
@@ -55,6 +56,7 @@ def make_gate_dirs(dir_name, path_to_templates):
         source = join(path_to_templates,f)  
         destination = join(dir_name,"data",f)
         shutil.copyfile(source,destination)
+        slurm.dos2unix( destination, destination )
     # Copy over mac files
     for f in DATA["MACS_TO_COPY"]:
         source = join(path_to_templates,f)  

--- a/gate-pbt/templates/mac_template.txt
+++ b/gate-pbt/templates/mac_template.txt
@@ -135,7 +135,7 @@
 /gate/actor/dose3d/enableUncertaintyDose false
 /gate/actor/dose3d/enableNumberOfHits    false
 #/gate/actor/dose3d/normaliseDoseToMax   false
-/gate/actor/dose3d/enableDoseToWater     true
+/gate/actor/dose3d/enableDoseToWater     false
 
 #/gate/actor/addActor                 LETActor  let3d
 #/gate/actor/let3d/save               {path}/output/{run}_letActor.mhd


### PR DESCRIPTION
- Convert all files to UNIX eol chars when copying from templates
- Set 2E6 primaries per field as standard
- Set Gate's dose-to-water conversion to false as default
- No for loop in overrides.set_air_external; 33% faster